### PR TITLE
Renovate: disable status checks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,7 @@
       "automerge": true,
       "automergeType": "pr-comment",
       "automergeComment": "bors r+",
+      "requiredStatusChecks": null,
     },
   ],
 }


### PR DESCRIPTION
Renovate seems to get confused by the existing statuses. We simply want
it to comment `bors r+` as soon as it opens the PR, since bors will take
care of checking if it is mergeable.