### PR TITLE
fix: ensure to specifically use Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v2
       with:
-        python-version: '^3.9'
+        python-version: '3.9'
     - name: Install Go
       uses: actions/setup-go@v2
       with:


### PR DESCRIPTION
The Python scripts under `hack/` use `/usr/bin/env python3.9` to ensure
we have don't accidentally use an outdated version that might be
preinstalled.