### PR TITLE
Add last state of documentation-based SAM items

### DIFF
--- a/index-sources/sam.json
+++ b/index-sources/sam.json
@@ -1,0 +1,1064 @@
+{
+  "_attribution": {
+    "ContentRetrievedFrom": "https://github.com/awsdocs/aws-sam-developer-guide/tree/42be629401362fdadf87cfff061662d0d08c3968",
+    "Copyright": "Copyright 2023 Amazon Web Services, Inc.",
+    "License": "Apache License 2.0"
+  },
+  "items": {
+    "API Gateway extensions": {
+      "description": "API Gateway extensions are extensions to the OpenAPI specification that support the AWS-specific authorization and API Gateway-specific API integrations. For more information about API Gateway extensions, see [API Gateway Extensions to OpenAPI](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions.html).",
+      "filename": "sam-specification-api-gateway-extensions",
+      "source": "sam"
+    },
+    "API key example": {
+      "description": "You can control access to your APIs by requiring API keys within your AWS SAM template. To do this, you use the [ApiAuth](sam-property-api-apiauth.md) data type.",
+      "filename": "serverless-controlling-access-to-apis-keys",
+      "source": "sam"
+    },
+    "AWS Cloud Development Kit \\(AWS CDK\\)": {
+      "description": "You can use the AWS SAM CLI to locally test and build serverless applications defined using the AWS Cloud Development Kit (AWS CDK). Because the AWS SAM CLI works within the AWS CDK project structure, you can still use the [AWS CDK Toolkit](https://docs.aws.amazon.com/cdk/latest/guide/cli.html) for creating, modifying, and deploying your AWS CDK applications.",
+      "filename": "serverless-cdk",
+      "source": "sam"
+    },
+    "AWS CloudFormation resources generated when AWS::Serverless::Api is specified": {
+      "description": "When an `AWS::Serverless::Api` is specified, AWS Serverless Application Model (AWS SAM) always generates an `AWS::ApiGateway::RestApi` base AWS CloudFormation resource. In addition, it also always generates an `AWS::ApiGateway::Stage` and an `AWS::ApiGateway::Deployment` resource.",
+      "filename": "sam-specification-generated-resources-api",
+      "source": "sam"
+    },
+    "AWS CloudFormation resources generated when AWS::Serverless::Application is specified": {
+      "description": "When an `AWS::Serverless::Application` is specified, AWS Serverless Application Model (AWS SAM) generates an `AWS::CloudFormation::Stack` base AWS CloudFormation resource.",
+      "filename": "sam-specification-generated-resources-application",
+      "source": "sam"
+    },
+    "AWS CloudFormation resources generated when AWS::Serverless::Function is specified": {
+      "description": "When an `AWS::Serverless::Function` is specified, AWS Serverless Application Model (AWS SAM) always creates an `AWS::Lambda::Function` base AWS CloudFormation resource.",
+      "filename": "sam-specification-generated-resources-function",
+      "source": "sam"
+    },
+    "AWS CloudFormation resources generated when AWS::Serverless::HttpApi is specified": {
+      "description": "When an `AWS::Serverless::HttpApi` is specified, AWS Serverless Application Model (AWS SAM) generates an `AWS::ApiGatewayV2::Api` base AWS CloudFormation resource.",
+      "filename": "sam-specification-generated-resources-httpapi",
+      "source": "sam"
+    },
+    "AWS CloudFormation resources generated when AWS::Serverless::LayerVersion is specified": {
+      "description": "When an `AWS::Serverless::LayerVersion` is specified, AWS Serverless Application Model (AWS SAM) generates an `AWS::Lambda::LayerVersion` base AWS CloudFormation resource.",
+      "filename": "sam-specification-generated-resources-layerversion",
+      "source": "sam"
+    },
+    "AWS CloudFormation resources generated when AWS::Serverless::SimpleTable is specified": {
+      "description": "When an `AWS::Serverless::SimpleTable` is specified, AWS Serverless Application Model (AWS SAM) generates an `AWS::DynamoDB::Table` base AWS CloudFormation resource.",
+      "filename": "sam-specification-generated-resources-simpletable",
+      "source": "sam"
+    },
+    "AWS CloudFormation resources generated when AWS::Serverless::StateMachine is specified": {
+      "description": "When an `AWS::Serverless::StateMachine` is specified, AWS Serverless Application Model (AWS SAM) generates an `AWS::StepFunctions::StateMachine` base AWS CloudFormation resource.",
+      "filename": "sam-specification-generated-resources-statemachine",
+      "source": "sam"
+    },
+    "AWS CloudFormation resources generated when you specify AWS::Serverless::Connector": {
+      "description": "**Note**",
+      "filename": "sam-specification-generated-resources-connector",
+      "source": "sam"
+    },
+    "AWS SAM CLI Terraform support": {
+      "description": "|  |",
+      "filename": "terraform-support",
+      "source": "sam"
+    },
+    "AWS SAM CLI command reference": {
+      "description": "This section is the reference for the AWS SAM CLI commands. For instructions about installing the AWS SAM CLI, see [Installing the AWS SAM CLI](install-sam-cli.md).",
+      "filename": "serverless-sam-cli-command-reference",
+      "source": "sam"
+    },
+    "AWS SAM CLI configuration file": {
+      "description": "The AWS SAM CLI supports a project-level configuration file that stores default parameters for its commands. This configuration file is in the [TOML file format](https://toml.io/en/), and the default file name is `samconfig.toml`. The file's default location is your project's root directory, which contains your project's AWS SAM template file.",
+      "filename": "serverless-sam-cli-config",
+      "source": "sam"
+    },
+    "AWS SAM CLI reference": {
+      "description": "This section is the reference for the AWS Serverless Application Model Command Line Interface (AWS SAM CLI).",
+      "filename": "reference-sam-cli",
+      "source": "sam"
+    },
+    "AWS SAM CLI troubleshooting": {
+      "description": "Troubleshoot error messages when using, installing, and managing the AWS Serverless Application Model Command Line Interface (AWS SAM CLI).",
+      "filename": "sam-cli-troubleshooting",
+      "source": "sam"
+    },
+    "AWS SAM CLI with Terraform reference": {
+      "description": "|  |",
+      "filename": "terraform-reference",
+      "source": "sam"
+    },
+    "AWS SAM connector reference": {
+      "description": "This section contains reference information for the AWS Serverless Application Model (AWS SAM) connector resource type. For an introduction to connectors, see [Managing resource permissions with AWS SAM connectors](managing-permissions-connectors.md).",
+      "filename": "reference-sam-connector",
+      "source": "sam"
+    },
+    "AWS SAM policy templates": {
+      "description": "The AWS Serverless Application Model (AWS SAM) allows you to choose from a list of policy templates to scope the permissions of your Lambda functions and AWS Step Functions state machines to the resources that are used by your application.",
+      "filename": "serverless-policy-templates",
+      "source": "sam"
+    },
+    "AWS SAM prerequisites": {
+      "description": "Complete the following prerequisites before installing and using the AWS Serverless Application Model Command Line Interface (AWS SAM CLI).",
+      "filename": "prerequisites",
+      "source": "sam"
+    },
+    "AWS SAM reference": {
+      "description": "## AWS SAM specification<a name=\"serverless-sam-spec\"></a>",
+      "filename": "serverless-sam-reference",
+      "source": "sam"
+    },
+    "AWS SAM resource and property reference": {
+      "description": "This section contains reference information for the AWS SAM resource and property types.",
+      "filename": "sam-specification-resources-and-properties",
+      "source": "sam"
+    },
+    "AWS SAM template Metadata section properties": {
+      "description": "`AWS::ServerlessRepo::Application` is a metadata key that you can use to specify application information that you want published to the AWS Serverless Application Repository.",
+      "filename": "serverless-sam-template-publishing-applications-metadata-properties",
+      "source": "sam"
+    },
+    "AWS SAM template anatomy": {
+      "description": "An AWS SAM template file closely follows the format of an AWS CloudFormation template file, which is described in [Template anatomy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html) in the *AWS CloudFormation User Guide*. The primary differences between AWS SAM template files and AWS CloudFormation template files are the following:",
+      "filename": "sam-specification-template-anatomy",
+      "source": "sam"
+    },
+    "AWS Serverless Application Model Developer Guide": {
+      "description": "-----",
+      "filename": "index",
+      "source": "sam"
+    },
+    "AWS Serverless Application Model \\(AWS SAM\\) specification": {
+      "description": "You use the AWS SAM specification to define your serverless application. This section provides details for the AWS SAM template sections, resources types, resource properties, data types, resource attributes, intrinsic functions, and API Gateway extensions that you can use in AWS SAM templates.",
+      "filename": "sam-specification",
+      "source": "sam"
+    },
+    "AWS::Serverless::Api": {
+      "description": "Creates a collection of Amazon API Gateway resources and methods that can be invoked through HTTPS endpoints.",
+      "filename": "sam-resource-api",
+      "source": "sam"
+    },
+    "AWS::Serverless::Application": {
+      "description": "Embeds a serverless application from the [AWS Serverless Application Repository](https://serverlessrepo.aws.amazon.com/applications) or from an Amazon S3 bucket as a nested application. Nested applications are deployed as nested [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-stack.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-stack.html) resources, which can contain multiple other resources including other [AWS::Serverless::Application](#sam-resource-application) resources.",
+      "filename": "sam-resource-application",
+      "source": "sam"
+    },
+    "AWS::Serverless::Connector": {
+      "description": "Configures permissions between two resources. For an introduction to connectors, see [Managing resource permissions with AWS SAM connectors](managing-permissions-connectors.md).",
+      "filename": "sam-resource-connector",
+      "source": "sam"
+    },
+    "AWS::Serverless::Function": {
+      "description": "Creates an AWS Lambda function, an AWS Identity and Access Management (IAM) execution role, and event source mappings that trigger the function.",
+      "filename": "sam-resource-function",
+      "source": "sam"
+    },
+    "AWS::Serverless::HttpApi": {
+      "description": "Creates an Amazon API Gateway HTTP API, which enables you to create RESTful APIs with lower latency and lower costs than REST APIs. For more information, see [Working with HTTP APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html) in the *API Gateway Developer Guide*.",
+      "filename": "sam-resource-httpapi",
+      "source": "sam"
+    },
+    "AWS::Serverless::LayerVersion": {
+      "description": "Creates a Lambda LayerVersion that contains library or runtime code needed by a Lambda Function.",
+      "filename": "sam-resource-layerversion",
+      "source": "sam"
+    },
+    "AWS::Serverless::SimpleTable": {
+      "description": "Creates a DynamoDB table with a single attribute primary key. It is useful when data only needs to be accessed via a primary key.",
+      "filename": "sam-resource-simpletable",
+      "source": "sam"
+    },
+    "AWS::Serverless::StateMachine": {
+      "description": "Creates an AWS Step Functions state machine, which you can use to orchestrate AWS Lambda functions and other AWS resources to form complex and robust workflows.",
+      "filename": "sam-resource-statemachine",
+      "source": "sam"
+    },
+    "AlexaSkill": {
+      "description": "The object describing an `AlexaSkill` event source type.",
+      "filename": "sam-property-function-alexaskill",
+      "source": "sam"
+    },
+    "Amazon Cognito user pool example": {
+      "description": "You can control access to your APIs by defining Amazon Cognito user pools within your AWS SAM template. To do this, you use the [ApiAuth](sam-property-api-apiauth.md) data type.",
+      "filename": "serverless-controlling-access-to-apis-cognito-user-pool",
+      "source": "sam"
+    },
+    "Api": {
+      "description": "The object describing an `Api` event source type. If an [AWS::Serverless::Api](sam-resource-api.md) resource is defined, the path and method values must correspond to an operation in the OpenAPI definition of the API.",
+      "filename": "sam-property-function-api",
+      "source": "sam"
+    },
+    "ApiAuth": {
+      "description": "Configure authorization to control access to your API Gateway API.",
+      "filename": "sam-property-api-apiauth",
+      "source": "sam"
+    },
+    "ApiDefinition": {
+      "description": "An OpenAPI document defining the API.",
+      "filename": "sam-property-api-apidefinition",
+      "source": "sam"
+    },
+    "ApiFunctionAuth": {
+      "description": "Configures authorization at the event level, for a specific API, path, and method.",
+      "filename": "sam-property-function-apifunctionauth",
+      "source": "sam"
+    },
+    "ApiStateMachineAuth": {
+      "description": "Configures authorization at the event level, for a specific API, path, and method.",
+      "filename": "sam-property-statemachine-apistatemachineauth",
+      "source": "sam"
+    },
+    "ApiUsagePlan": {
+      "description": "Configures a usage plan for an API Gateway API. For more information about usage plans, see [Create and Use Usage Plans with API Keys](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html) in the *API Gateway Developer Guide*.",
+      "filename": "sam-property-api-apiusageplan",
+      "source": "sam"
+    },
+    "ApplicationLocationObject": {
+      "description": "An application that has been published to the [AWS Serverless Application Repository](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).",
+      "filename": "sam-property-application-applicationlocationobject",
+      "source": "sam"
+    },
+    "Authoring serverless applications": {
+      "description": "When you author a serverless application using AWS SAM, you construct an AWS SAM template to declare and configure the components of your application.",
+      "filename": "serverless-authoring",
+      "source": "sam"
+    },
+    "Building AWS CDK applications": {
+      "description": "The AWS SAM CLI provides support for building Lambda functions and layers defined in your AWS CDK application with [sam build](sam-cli-command-reference-sam-build.md).",
+      "filename": "serverless-cdk-building",
+      "source": "sam"
+    },
+    "Building Node\\.js Lambda functions with esbuild": {
+      "description": "To build and package Node.js AWS Lambda functions, you can use the AWS SAM CLI with the esbuild JavaScript bundler. The esbuild bundler supports Lambda functions that you write in TypeScript.",
+      "filename": "serverless-sam-cli-using-build-typescript",
+      "source": "sam"
+    },
+    "Building Rust Lambda functions with Cargo Lambda": {
+      "description": "|  |",
+      "filename": "building-rust",
+      "source": "sam"
+    },
+    "Building \\.NET 7 Lambda functions with Native AOT compilation": {
+      "description": "Build and package your .NET 7 AWS Lambda functions with the AWS Serverless Application Model (AWS SAM), utilizing Native Ahead-of-Time (AOT) compilation to improve AWS Lambda cold-start times.",
+      "filename": "build-dotnet7",
+      "source": "sam"
+    },
+    "Building applications": {
+      "description": "To build your serverless application, use the `sam build` command. This command also gathers the build artifacts of your application's dependencies and places them in the proper format and location for next steps, such as locally testing, packaging, and deploying.",
+      "filename": "serverless-sam-cli-using-build",
+      "source": "sam"
+    },
+    "Building custom runtimes": {
+      "description": "You can use the `sam build` command to build custom runtimes required for your Lambda function. You declare your Lambda function to use a custom runtime by specifying `Runtime: provided` for the function.",
+      "filename": "building-custom-runtimes",
+      "source": "sam"
+    },
+    "Building layers": {
+      "description": "You can use AWS SAM to build custom layers. For information about layers, see [AWS Lambda layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) in the *AWS Lambda Developer Guide*.",
+      "filename": "building-layers",
+      "source": "sam"
+    },
+    "Building serverless applications": {
+      "description": "Building your serverless application involves taking your AWS SAM template file, application code, and any applicable language-specific files and dependencies, and placing all build artifacts in the proper format and location for subsquent steps in your workflow.",
+      "filename": "serverless-building",
+      "source": "sam"
+    },
+    "CloudWatchEvent": {
+      "description": "The object describing a `CloudWatchEvent` event source type.",
+      "filename": "sam-property-statemachine-statemachinecloudwatchevent",
+      "source": "sam"
+    },
+    "CloudWatchLogs": {
+      "description": "The object describing a `CloudWatchLogs` event source type.",
+      "filename": "sam-property-function-cloudwatchlogs",
+      "source": "sam"
+    },
+    "Cognito": {
+      "description": "The object describing a `Cognito` event source type.",
+      "filename": "sam-property-function-cognito",
+      "source": "sam"
+    },
+    "CognitoAuthorizationIdentity": {
+      "description": "This property can be used to specify an IdentitySource in an incoming request for an authorizer. For more information about IdentitySource see the [ApiGateway Authorizer OpenApi extension](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authorizer.html).",
+      "filename": "sam-property-api-cognitoauthorizationidentity",
+      "source": "sam"
+    },
+    "CognitoAuthorizer": {
+      "description": "Define a Amazon Cognito User Pool authorizer.",
+      "filename": "sam-property-api-cognitoauthorizer",
+      "source": "sam"
+    },
+    "Configuring code signing for AWS SAM applications": {
+      "description": "You can use AWS SAM to enable code signing with your serverless applications to help ensure that only trusted code is deployed. For more information about the code signing feature, see [Configuring code signing for Lambda functions](https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html) in the *AWS Lambda Developer Guide*.",
+      "filename": "authoring-codesigning",
+      "source": "sam"
+    },
+    "Configuring the AWS SAM CLI": {
+      "description": "Configure credentials, basic settings, and project settings for the AWS Serverless Application Model Command Line Interface (AWS SAM CLI).",
+      "filename": "using-sam-cli-configure",
+      "source": "sam"
+    },
+    "Controlling access to API Gateway APIs": {
+      "description": "To control who can access your Amazon API Gateway APIs, you can enable authorization within your AWS SAM template.",
+      "filename": "serverless-controlling-access-to-apis",
+      "source": "sam"
+    },
+    "CorsConfiguration": {
+      "description": "Manage cross-origin resource sharing (CORS) for your API Gateway APIs. Specify the domain to allow as a string or specify a dictionary with additional Cors configuration. NOTE: Cors requires SAM to modify your OpenAPI definition, so it only works with inline OpenApi defined in the `DefinitionBody` property.",
+      "filename": "sam-property-api-corsconfiguration",
+      "source": "sam"
+    },
+    "Customized response example": {
+      "description": "You can customize some API Gateway error responses by defining response headers within your AWS SAM template. To do this, you use the [Gateway Response Object](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#gateway-response-object) data type.",
+      "filename": "serverless-controlling-access-to-apis-customize-response",
+      "source": "sam"
+    },
+    "Customizing starter pipelines": {
+      "description": "As a CI/CD administrator, you may want to customize a starter pipeline template, and associated guided prompts, that developers in your organization can use to create pipeline configurations.",
+      "filename": "serverless-customizing-starter-pipelines",
+      "source": "sam"
+    },
+    "DeadLetterConfig": {
+      "description": "The object used to specify the Amazon Simple Queue Service (Amazon SQS) queue where EventBridge sends events after a failed target invocation. Invocation can fail, for example, when sending an event to a Lambda function that doesn\u2019t exist, or insufficient permissions to invoke the Lambda function. For more information, see [Event retry policy and using dead-letter queues](https://docs.aws.amazon.com/eventbridge/latest/userguide/rule-dlq.html) in the *Amazon EventBridge User Guide*.",
+      "filename": "sam-property-function-scheduledeadletterconfig",
+      "source": "sam"
+    },
+    "DeadLetterQueue": {
+      "description": "Specifies an SQS queue or SNS topic that AWS Lambda (Lambda) sends events to when it can't process them. For more information about dead letter queue functionality, see [AWS Lambda Function Dead Letter Queues](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#dlq).",
+      "filename": "sam-property-function-deadletterqueue",
+      "source": "sam"
+    },
+    "Deploying AWS CDK applications": {
+      "description": "The AWS SAM CLI doesn't support deploying AWS CDK applications. Use `cdk deploy` to deploy your application. For more information, see [AWS CDK Toolkit (cdk command)](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html) in the *AWS Cloud Development Kit (AWS CDK) Developer Guide*",
+      "filename": "serverless-cdk-deploying",
+      "source": "sam"
+    },
+    "Deploying serverless applications": {
+      "description": "AWS SAM uses AWS CloudFormation as the underlying deployment mechanism. For more information, see [What is AWS CloudFormation?](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/) in the *AWS CloudFormation User Guide*. The standard inputs to deploying serverless applications are the build artifacts created using the [sam build](sam-cli-command-reference-sam-build.md) command. For more information about sam build, see [Building serverless applications](serverless-building.md).",
+      "filename": "serverless-deploying",
+      "source": "sam"
+    },
+    "Deploying serverless applications gradually": {
+      "description": "AWS Serverless Application Model (AWS SAM) comes built-in with [CodeDeploy](https://docs.aws.amazon.com/codedeploy/latest/userguide/welcome.html) to provide gradual AWS Lambda deployments. With just a few lines of configuration, AWS SAM does the following for you:",
+      "filename": "automating-updates-to-serverless-apps",
+      "source": "sam"
+    },
+    "Deploying using AWS CodePipeline": {
+      "description": "To configure your [AWS CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/userguide/welcome.html) pipeline to automate the build and deployment of your AWS SAM application, your AWS CloudFormation template and `buildspec.yml` file must contain lines that do the following:",
+      "filename": "deploying-using-codepipeline",
+      "source": "sam"
+    },
+    "Deploying using Bitbucket Pipelines": {
+      "description": "To configure your [Bitbucket Pipeline](https://support.atlassian.com/bitbucket-cloud/docs/get-started-with-bitbucket-pipelines/) to automate the build and deployment of your AWS SAM application, your `bitbucket-pipelines.yml` file must contain lines that do the following:",
+      "filename": "deploying-using-bitbucket",
+      "source": "sam"
+    },
+    "Deploying using GitHub Actions": {
+      "description": "To configure your [GitHub](https://github.com/) pipeline to automate the build and deployment of your AWS SAM application, you must first install the AWS SAM command line interface (CLI) on your host. You can use [GitHub Actions](https://github.com/features/actions) in your GitHub workflow to help with this setup.",
+      "filename": "deploying-using-github",
+      "source": "sam"
+    },
+    "Deploying using GitLab CI/CD": {
+      "description": "To configure your [GitLab](https://about.gitlab.com) pipeline to automate the build and deployment of your AWS SAM application, your `gitlab-ci.yml` file must contain lines that do the following:",
+      "filename": "deploying-using-gitlab",
+      "source": "sam"
+    },
+    "Deploying using Jenkins": {
+      "description": "To configure your [Jenkins](https://www.jenkins.io/) pipeline to automate the build and deployment of your AWS SAM application, your `Jenkinsfile` must contain lines that do the following:",
+      "filename": "deploying-using-jenkins",
+      "source": "sam"
+    },
+    "DeploymentPreference": {
+      "description": "Specifies the configurations to enable gradual Lambda deployments. For more information about configuring gradual Lambda deployments, see [Deploying serverless applications gradually](automating-updates-to-serverless-apps.md).",
+      "filename": "sam-property-function-deploymentpreference",
+      "source": "sam"
+    },
+    "Document history for AWS SAM": {
+      "description": "The following table describes the important changes in each release of the *AWS Serverless Application Model Developer Guide*. For notifications about updates to this documentation, you can subscribe to an RSS feed.",
+      "filename": "doc-history",
+      "source": "sam"
+    },
+    "DocumentDB": {
+      "description": "The object describing a `DocumentDB` event source type. For more information, see [Using AWS Lambda with Amazon DocumentDB](https://docs.aws.amazon.com/lambda/latest/dg/with-documentdb.html) in the *AWS Lambda Developer Guide*.",
+      "filename": "sam-property-function-documentdb",
+      "source": "sam"
+    },
+    "DomainConfiguration": {
+      "description": "Configures a custom domain for an API.",
+      "filename": "sam-property-api-domainconfiguration",
+      "source": "sam"
+    },
+    "DynamoDB": {
+      "description": "The object describing a `DynamoDB` event source type. For more information, see [Using AWS Lambda with Amazon DynamoDB](https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html) in the *AWS Lambda Developer Guide*.",
+      "filename": "sam-property-function-dynamodb",
+      "source": "sam"
+    },
+    "EndpointConfiguration": {
+      "description": "The endpoint type of a REST API.",
+      "filename": "sam-property-api-endpointconfiguration",
+      "source": "sam"
+    },
+    "EventBridgeRule": {
+      "description": "The object describing an `EventBridgeRule` event source type, which sets your state machine as the target for an Amazon EventBridge rule. For more information, see [What Is Amazon EventBridge?](https://docs.aws.amazon.com/eventbridge/latest/userguide/what-is-amazon-eventbridge.html) in the *Amazon EventBridge User Guide*.",
+      "filename": "sam-property-statemachine-statemachineeventbridgerule",
+      "source": "sam"
+    },
+    "EventInvokeConfiguration": {
+      "description": "Configuration options for [asynchronous](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html) Lambda Alias or Version invocations.",
+      "filename": "sam-property-function-eventinvokeconfiguration",
+      "source": "sam"
+    },
+    "EventInvokeDestinationConfiguration": {
+      "description": "A configuration object that specifies the destination of an event after Lambda processes it.",
+      "filename": "sam-property-function-eventinvokedestinationconfiguration",
+      "source": "sam"
+    },
+    "EventSource": {
+      "description": "The object describing the source of events which trigger the state machine. Each event consists of a type and a set of properties that depend on that type. For more information about the properties of each event source, see the subtopic corresponding to that type.",
+      "filename": "sam-property-statemachine-statemachineeventsource",
+      "source": "sam"
+    },
+    "Example serverless applications": {
+      "description": "The following examples show you how to download, test, and deploy a number of additional serverless applications\u2014including how to configure event sources and AWS resources.",
+      "filename": "serverless-example-applications",
+      "source": "sam"
+    },
+    "FunctionCode": {
+      "description": "The [deployment package](https://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html) for a Lambda function.",
+      "filename": "sam-property-function-functioncode",
+      "source": "sam"
+    },
+    "FunctionUrlConfig": {
+      "description": "Creates an AWS Lambda function URL with the specified configuration parameters. A Lambda function URL is an HTTPS endpoint that you can use to invoke your function.",
+      "filename": "sam-property-function-functionurlconfig",
+      "source": "sam"
+    },
+    "Generated AWS CloudFormation resources": {
+      "description": "When AWS Serverless Application Model (AWS SAM) processes your AWS SAM template file, it generates one or more AWS CloudFormation resources. The set of AWS CloudFormation resources that AWS SAM generates differs depending on the scenarios that you specify. A *scenario* is the combination of AWS SAM resources and properties specified in your template file. You can reference the generated AWS CloudFormation resources elsewhere within your template file, similar to how you reference resources that you declare explicitly in your template file.",
+      "filename": "sam-specification-generated-resources",
+      "source": "sam"
+    },
+    "Generating sample event payloads": {
+      "description": "To make local development and testing of Lambda functions easier, you can generate and customize event payloads for a number of AWS services like API Gateway, AWS CloudFormation, Amazon S3, and so on.",
+      "filename": "serverless-sam-cli-using-generate-event",
+      "source": "sam"
+    },
+    "Generating starter CI/CD pipelines": {
+      "description": "When you are ready to deploy your serverless application in an automated manner, you can generate a deployment pipeline for your CI/CD system of choice. AWS SAM provides a set of starter pipeline templates with which you can generate pipelines in minutes using the [sam pipeline init](sam-cli-command-reference-sam-pipeline-init.md) command.",
+      "filename": "serverless-generating-example-ci-cd",
+      "source": "sam"
+    },
+    "Generating starter pipeline for AWS CodePipeline": {
+      "description": "To generate a starter pipeline configuration for AWS CodePipeline, perform the following tasks in this order:",
+      "filename": "serverless-generating-example-ci-cd-codepipeline",
+      "source": "sam"
+    },
+    "Generating starter pipelines for Jenkins, GitLab CI/CD, GitHub Actions, or Bitbucket Pipelines": {
+      "description": "To generate a starter pipeline configuration for Jenkins, GitLab CI/CD, GitHub Actions, or Bitbucket Pipelines perform the following tasks in this order:",
+      "filename": "serverless-generating-example-ci-cd-others",
+      "source": "sam"
+    },
+    "Getting started with AWS SAM": {
+      "description": "Get started with the AWS Serverless Application Model (AWS SAM) by installing the AWS SAM Command Line Interface (AWS SAM CLI).",
+      "filename": "serverless-getting-started",
+      "source": "sam"
+    },
+    "Getting started with AWS SAM and the AWS CDK": {
+      "description": "This topic describes what you need to use the AWS SAM CLI with AWS CDK applications, and provides instructions for building and locally testing a simple AWS CDK application.",
+      "filename": "serverless-cdk-getting-started",
+      "source": "sam"
+    },
+    "Getting started with Terraform support for AWS SAM CLI": {
+      "description": "|  |",
+      "filename": "gs-terraform-support",
+      "source": "sam"
+    },
+    "Globals section of the AWS SAM template": {
+      "description": "Sometimes resources that you declare in an AWS SAM template have common configurations. For example, you might have an application with multiple `AWS::Serverless::Function` resources that have identical `Runtime`, `Memory`, `VPCConfig`, `Environment`, and `Cors` configurations. Instead of duplicating this information in every resource, you can declare them once in the `Globals` section and let your resources inherit them.",
+      "filename": "sam-specification-template-anatomy-globals",
+      "source": "sam"
+    },
+    "Hooks": {
+      "description": "Validation Lambda functions that are run before and after traffic shifting.",
+      "filename": "sam-property-function-hooks",
+      "source": "sam"
+    },
+    "HttpApi": {
+      "description": "The object describing an event source with type HttpApi.",
+      "filename": "sam-property-function-httpapi",
+      "source": "sam"
+    },
+    "HttpApiAuth": {
+      "description": "Configure authorization to control access to your Amazon API Gateway HTTP API.",
+      "filename": "sam-property-httpapi-httpapiauth",
+      "source": "sam"
+    },
+    "HttpApiCorsConfiguration": {
+      "description": "Manage cross-origin resource sharing (CORS) for your HTTP APIs. Specify the domain to allow as a string or specify a dictionary with additional Cors configuration. NOTE: Cors requires SAM to modify your OpenAPI definition, so it only works with inline OpenApi defined in the `DefinitionBody` property.",
+      "filename": "sam-property-httpapi-httpapicorsconfiguration",
+      "source": "sam"
+    },
+    "HttpApiDefinition": {
+      "description": "An OpenAPI document defining the API.",
+      "filename": "sam-property-httpapi-httpapidefinition",
+      "source": "sam"
+    },
+    "HttpApiDomainConfiguration": {
+      "description": "Configures a custom domain for an API.",
+      "filename": "sam-property-httpapi-httpapidomainconfiguration",
+      "source": "sam"
+    },
+    "HttpApiFunctionAuth": {
+      "description": "Configures authorization at the event level.",
+      "filename": "sam-property-function-httpapifunctionauth",
+      "source": "sam"
+    },
+    "IAM permission example": {
+      "description": "You can control access to your APIs by defining IAM permissions within your AWS SAM template. To do this, you use the [ApiAuth](sam-property-api-apiauth.md) data type.",
+      "filename": "serverless-controlling-access-to-apis-permissions",
+      "source": "sam"
+    },
+    "Image repositories": {
+      "description": "AWS SAM simplifies continuous integration and continuous delivery (CI/CD) tasks for serverless applications with the help of build container images. The images that AWS SAM provides include the AWS SAM command line interface (CLI) and build tools for a number of supported AWS Lambda runtimes. This make it easier to build and package serverless applications using the AWS SAM CLI. You can use these images with CI/CD systems to automate the building and deployment of AWS SAM applications. For examples, see [Deploying using CI/CD systems](serverless-deploying.md#serverless-deploying-ci-cd).",
+      "filename": "serverless-image-repositories",
+      "source": "sam"
+    },
+    "Important notes": {
+      "description": "This section contains important notes and known issues for AWS Serverless Application Model.",
+      "filename": "important-notes",
+      "source": "sam"
+    },
+    "Installing Docker to use with the AWS SAM CLI": {
+      "description": "Docker is an application that runs containers on your machine. With Docker, AWS SAM can provide a local environment similar to AWS Lambda as a container to build, test, and debug your serverless applications.",
+      "filename": "install-docker",
+      "source": "sam"
+    },
+    "Installing Homebrew to use with the AWS SAM CLI": {
+      "description": "You can optionally use Homebrew to install and manage versions of the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) on macOS and Linux machines. To use Homebrew, follow the installation instructions here.",
+      "filename": "install-homebrew",
+      "source": "sam"
+    },
+    "Installing the AWS SAM CLI": {
+      "description": "Install the latest release of the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) on supported operating systems.",
+      "filename": "install-sam-cli",
+      "source": "sam"
+    },
+    "Integrating with automated tests": {
+      "description": "You can use the `sam local invoke` command to manually test your code by running Lambda functions locally. With the AWS SAM CLI, you can easily author automated integration tests by first running tests against local Lambda functions before deploying to the AWS Cloud.",
+      "filename": "serverless-sam-cli-using-automated-tests",
+      "source": "sam"
+    },
+    "Intrinsic functions": {
+      "description": "Intrinsic functions are built-in functions that enable you to assign values to properties that are only available at runtime. For more information about intrinsic functions, see [Intrinsic Function Reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) in the *AWS CloudFormation User Guide*.",
+      "filename": "sam-specification-intrinsic-functions",
+      "source": "sam"
+    },
+    "Invoking Lambda functions locally": {
+      "description": "You can invoke your AWS Lambda function locally by using the `sam local invoke` AWS SAM CLI command and providing the function's logical ID and an event file. Alternatively, sam local invoke also accepts `stdin` as an event. For more information about events, see [Event](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-concepts.html#gettingstarted-concepts-event) in the *AWS Lambda Developer Guide*. For information about event message formats from different AWS services, see [Using AWS Lambda with other services](https://docs.aws.amazon.com/lambda/latest/dg/lambda-services.html) in the *AWS Lambda Developer Guide*.",
+      "filename": "serverless-sam-cli-using-invoke",
+      "source": "sam"
+    },
+    "IoTRule": {
+      "description": "The object describing an `IoTRule` event source type.",
+      "filename": "sam-property-function-iotrule",
+      "source": "sam"
+    },
+    "Kinesis": {
+      "description": "The object describing a `Kinesis` event source type. For more information, see [Using AWS Lambda with Amazon Kinesis](https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html) in the *AWS Lambda Developer Guide*.",
+      "filename": "sam-property-function-kinesis",
+      "source": "sam"
+    },
+    "Lambda authorizer examples": {
+      "description": "The `AWS::Serverless::Api` resource type supports two types of Lambda authorizers: `TOKEN` authorizers and `REQUEST` authorizers. The `AWS::Serverless::HttpApi` resource type supports only `REQUEST` authorizers. The following are examples of each type.",
+      "filename": "serverless-controlling-access-to-apis-lambda-authorizer",
+      "source": "sam"
+    },
+    "LambdaAuthorizationIdentity": {
+      "description": "Use property can be used to specify an IdentitySource in an incoming request for a Lambda authorizer. For more information about identity sources, see [Identity sources](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html#http-api-lambda-authorizer.identity-sources) in the *API Gateway Developer Guide*.",
+      "filename": "sam-property-httpapi-lambdaauthorizationidentity",
+      "source": "sam"
+    },
+    "LambdaAuthorizer": {
+      "description": "Configure a Lambda authorizer to control access to your Amazon API Gateway HTTP API with an AWS Lambda function.",
+      "filename": "sam-property-httpapi-lambdaauthorizer",
+      "source": "sam"
+    },
+    "LambdaRequestAuthorizationIdentity": {
+      "description": "This property can be used to specify an IdentitySource in an incoming request for an authorizer. For more information about IdentitySource see the [ApiGateway Authorizer OpenApi extension](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authorizer.html).",
+      "filename": "sam-property-api-lambdarequestauthorizationidentity",
+      "source": "sam"
+    },
+    "LambdaRequestAuthorizer": {
+      "description": "Configure a Lambda Authorizer to control access to your API with a Lambda function.",
+      "filename": "sam-property-api-lambdarequestauthorizer",
+      "source": "sam"
+    },
+    "LambdaTokenAuthorizationIdentity": {
+      "description": "This property can be used to specify an IdentitySource in an incoming request for an authorizer. For more information about IdentitySource see the [ApiGateway Authorizer OpenApi extension](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authorizer.html).",
+      "filename": "sam-property-api-lambdatokenauthorizationidentity",
+      "source": "sam"
+    },
+    "LambdaTokenAuthorizer": {
+      "description": "Configure a Lambda Authorizer to control access to your API with a Lambda function.",
+      "filename": "sam-property-api-lambdatokenauthorizer",
+      "source": "sam"
+    },
+    "LayerContent": {
+      "description": "A ZIP archive that contains the contents of an [Lambda layer](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).",
+      "filename": "sam-property-layerversion-layercontent",
+      "source": "sam"
+    },
+    "Locally testing AWS CDK applications": {
+      "description": "You can use the AWS SAM CLI to locally test your AWS CDK applications by running the following commands from the project root directory of your AWS CDK application:",
+      "filename": "serverless-cdk-testing",
+      "source": "sam"
+    },
+    "MQ": {
+      "description": "The object describing an `MQ` event source type. For more information, see [Using Lambda with Amazon MQ](https://docs.aws.amazon.com/lambda/latest/dg/with-mq.html) in the *AWS Lambda Developer Guide*.",
+      "filename": "sam-property-function-mq",
+      "source": "sam"
+    },
+    "MSK": {
+      "description": "The object describing an `MSK` event source type. For more information, see [Using AWS Lambda with Amazon MSK](https://docs.aws.amazon.com/lambda/latest/dg/with-msk.html) in the *AWS Lambda Developer Guide*.",
+      "filename": "sam-property-function-msk",
+      "source": "sam"
+    },
+    "Managing AWS SAM CLI versions": {
+      "description": "Manage your AWS Serverless Application Model Command Line Interface (AWS SAM CLI) versions through upgrading, downgrading, and uninstalling. Optionally, you can download and install the AWS SAM CLI nightly build.",
+      "filename": "manage-sam-cli-versions",
+      "source": "sam"
+    },
+    "Managing permissions with AWS CloudFormation mechanisms": {
+      "description": "To control access to AWS resources, the AWS Serverless Application Model (AWS SAM) can use the same mechanisms as AWS CloudFormation. For more information, see [Controlling access with AWS Identity and Access Management](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html) in the *AWS CloudFormation User Guide*.",
+      "filename": "sam-permissions-cloudformation",
+      "source": "sam"
+    },
+    "Managing resource access and permissions": {
+      "description": "For your AWS resources to interact with one another, the proper access and permissions must be configured between your resources, requiring the configuration of AWS Identity and Access Management (IAM) users, roles, and policies to accomplish your interaction in a secure manner. To learn more, see [Controlling access with AWS Identity and Access Management](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html) in the *AWS CloudFormation User Guide*.",
+      "filename": "sam-permissions",
+      "source": "sam"
+    },
+    "Managing resource permissions with AWS SAM connectors": {
+      "description": "**Topics**",
+      "filename": "managing-permissions-connectors",
+      "source": "sam"
+    },
+    "Modifying your existing CI/CD pipelines": {
+      "description": "The procedures for your existing CI/CD pipeline to deploy serverless applications using AWS SAM are slightly different depending on which CI/CD system you are using.",
+      "filename": "serverless-deploying-modify-pipeline",
+      "source": "sam"
+    },
+    "Monitor your serverless applications with CloudWatch Application Insights": {
+      "description": "Amazon CloudWatch Application Insights helps you monitor the AWS resources in your applications to help identify potential issues. It can analyze AWS resource data for signs of problems and build automated dashboards to visualize them. You can configure CloudWatch Application Insights to use with your AWS Serverless Application Model (AWS SAM) applications. To learn more about CloudWatch Application Insights, see [Amazon CloudWatch Application Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch-application-insights.html) in the *Amazon CloudWatch User Guide*.",
+      "filename": "monitor-app-insights",
+      "source": "sam"
+    },
+    "Monitoring serverless applications": {
+      "description": "Configure and perform monitoring of your AWS Serverless Application Model (AWS SAM) applications.",
+      "filename": "serverless-monitoring",
+      "source": "sam"
+    },
+    "OAuth 2\\.0/JWT authorizer example": {
+      "description": "You can control access to your APIs using JWTs as part of [OpenID Connect (OIDC)](https://openid.net/specs/openid-connect-core-1_0.html) and [OAuth 2.0](https://oauth.net/2/) frameworks. To do this, you use the [HttpApiAuth](sam-property-httpapi-httpapiauth.md) data type.",
+      "filename": "serverless-controlling-access-to-apis-oauth2-authorizer",
+      "source": "sam"
+    },
+    "OAuth2Authorizer": {
+      "description": "Definition for an OAuth 2.0 authorizer, also known to as a JSON Web Token (JWT) authorizer.",
+      "filename": "sam-property-httpapi-oauth2authorizer",
+      "source": "sam"
+    },
+    "OnFailure": {
+      "description": "A destination for events that failed processing.",
+      "filename": "sam-property-function-onfailure",
+      "source": "sam"
+    },
+    "OnSuccess": {
+      "description": "A destination for events that were processed successfully.",
+      "filename": "sam-property-function-onsuccess",
+      "source": "sam"
+    },
+    "Orchestrating AWS resources with AWS Step Functions": {
+      "description": "You can use [AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/) to orchestrate AWS Lambda functions and other AWS resources to form complex and robust workflows.",
+      "filename": "serverless-step-functions-in-sam",
+      "source": "sam"
+    },
+    "Passing additional runtime debug arguments": {
+      "description": "To pass additional runtime arguments when you're debugging your function, use the environment variable `DEBUGGER_ARGS`. This passes a string of arguments directly into the run command that the AWS SAM CLI uses to start your function.",
+      "filename": "serverless-sam-cli-using-debugging-additional-arguments",
+      "source": "sam"
+    },
+    "Policy template list": {
+      "description": "The following are the available policy templates, along with the permissions that are applied to each one. AWS Serverless Application Model (AWS SAM) automatically populates the placeholder items (such as AWS Region and account ID) with the appropriate information.",
+      "filename": "serverless-policy-template-list",
+      "source": "sam"
+    },
+    "PrimaryKeyObject": {
+      "description": "The object describing the properties of a primary key.",
+      "filename": "sam-property-simpletable-primarykeyobject",
+      "source": "sam"
+    },
+    "Process Amazon S3 events": {
+      "description": "With this example application, you build on what you learned in the previous examples, and install a more complex application. This application consists of a Lambda function that's invoked by an Amazon S3 object upload event source. This exercise shows you how to access AWS resources and make AWS service calls through a Lambda function.",
+      "filename": "serverless-example-s3",
+      "source": "sam"
+    },
+    "Process DynamoDB events": {
+      "description": "With this example application, you build on what you learned in the overview and the Quick Start guide, and install another example application. This application consists of a Lambda function that's invoked by a DynamoDB table event source. The Lambda function is very simple\u2014it logs data that was passed in through the event source message.",
+      "filename": "serverless-example-ddb",
+      "source": "sam"
+    },
+    "Publishing serverless applications using the AWS SAM CLI": {
+      "description": "To make your AWS SAM application available for others to find and deploy, you can use the AWS SAM CLI to publish it to the AWS Serverless Application Repository. To publish your application using the AWS SAM CLI, you must define it using an AWS SAM template. You also must have tested it locally or in the AWS Cloud.",
+      "filename": "serverless-sam-template-publishing-applications",
+      "source": "sam"
+    },
+    "RequestModel": {
+      "description": "Configures a Request Model for a specific Api+Path+Method.",
+      "filename": "sam-property-function-requestmodel",
+      "source": "sam"
+    },
+    "RequestParameter": {
+      "description": "Configure Request Parameter for a specific Api+Path+Method.",
+      "filename": "sam-property-function-requestparameter",
+      "source": "sam"
+    },
+    "Resource attributes": {
+      "description": "Resource attributes are attributes that you can add to AWS SAM and AWS CloudFormation resources to control additional behaviors and relationships. For more information about resource attributes, see [Resource Attribute Reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-product-attribute-reference.html) in the *AWS CloudFormation User Guide*.",
+      "filename": "sam-specification-resource-attributes",
+      "source": "sam"
+    },
+    "Resource policy example": {
+      "description": "You can control access to your APIs by attaching a resource policy within your AWS SAM template. To do this, you use the [ApiAuth](sam-property-api-apiauth.md) data type.",
+      "filename": "serverless-controlling-access-to-apis-resource-policies",
+      "source": "sam"
+    },
+    "ResourcePolicyStatement": {
+      "description": "Configures a resource policy for all methods and paths of an API. For more information about resource policies, see [Controlling access to an API with API Gateway resource policies](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-resource-policies.html) in the *API Gateway Developer Guide*.",
+      "filename": "sam-property-function-resourcepolicystatement",
+      "source": "sam"
+    },
+    "ResourceReference": {
+      "description": "A reference to a resource that the [AWS::Serverless::Connector](sam-resource-connector.md) resource type uses.",
+      "filename": "sam-property-connector-resourcereference",
+      "source": "sam"
+    },
+    "Route53Configuration": {
+      "description": "Configures the Route53 record sets for an API.",
+      "filename": "sam-property-httpapi-route53configuration",
+      "source": "sam"
+    },
+    "Running API Gateway locally": {
+      "description": "To start a local instance of Amazon API Gateway that you can use to test HTTP request/response functionality, use the `sam local start-api` AWS SAM CLI command. This functionality features hot reloading so that you can quickly develop and iterate over your functions.",
+      "filename": "serverless-sam-cli-using-start-api",
+      "source": "sam"
+    },
+    "S3": {
+      "description": "The object describing an `S3` event source type.",
+      "filename": "sam-property-function-s3",
+      "source": "sam"
+    },
+    "SNS": {
+      "description": "The object describing an `SNS` event source type.",
+      "filename": "sam-property-function-sns",
+      "source": "sam"
+    },
+    "SQS": {
+      "description": "The object describing an `SQS` event source type. For more information, see [Using AWS Lambda with Amazon SQS](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html) in the *AWS Lambda Developer Guide*.",
+      "filename": "sam-property-function-sqs",
+      "source": "sam"
+    },
+    "Schedule": {
+      "description": "The object describing a `Schedule` event source type, which sets your serverless function as the target of an Amazon EventBridge rule that triggers on a schedule. For more information, see [What Is Amazon EventBridge?](https://docs.aws.amazon.com/eventbridge/latest/userguide/what-is-amazon-eventbridge.html) in the *Amazon EventBridge User Guide*.",
+      "filename": "sam-property-function-schedule",
+      "source": "sam"
+    },
+    "ScheduleV2": {
+      "description": "The object describing a `ScheduleV2` event source type, which sets your state machine as the target of an Amazon EventBridge Scheduler event that triggers on a schedule. For more information, see [What is Amazon EventBridge Scheduler?](https://docs.aws.amazon.com/scheduler/latest/UserGuide/what-is-scheduler.html) in the *EventBridge Scheduler User Guide*.",
+      "filename": "sam-property-statemachine-statemachineschedulev2",
+      "source": "sam"
+    },
+    "Scheduling events with EventBridge Scheduler": {
+      "description": "## What is Amazon EventBridge Scheduler?<a name=\"using-eventbridge-scheduler-intro\"></a>",
+      "filename": "using-eventbridge-scheduler",
+      "source": "sam"
+    },
+    "SelfManagedKafka": {
+      "description": "The object describing a `SelfManagedKafka` event source type. For more information, see [Using AWS Lambda with with self-managed Apache Kafka](https://docs.aws.amazon.com/lambda/latest/dg/with-kafka.html) in the *AWS Lambda Developer Guide*.",
+      "filename": "sam-property-function-selfmanagedkafka",
+      "source": "sam"
+    },
+    "Serverless concepts": {
+      "description": "Learn about basic serverless concepts before using the AWS Serverless Application Model (AWS SAM).",
+      "filename": "what-is-concepts",
+      "source": "sam"
+    },
+    "Setting up AWS credentials": {
+      "description": "The AWS SAM command line interface (CLI) requires you to set AWS credentials so that it can make calls to AWS services on your behalf. For example, the AWS SAM CLI makes calls to Amazon S3 and AWS CloudFormation.",
+      "filename": "serverless-getting-started-set-up-credentials",
+      "source": "sam"
+    },
+    "SourceReference": {
+      "description": "A reference to a source resource that the [AWS::Serverless::Connector](sam-resource-connector.md) resource type uses.",
+      "filename": "sam-property-connector-sourcereference",
+      "source": "sam"
+    },
+    "SqsSubscriptionObject": {
+      "description": "Specify an existing SQS queue option to SNS event",
+      "filename": "sam-property-function-sqssubscriptionobject",
+      "source": "sam"
+    },
+    "Step\\-through debugging Lambda functions locally": {
+      "description": "You can use AWS SAM with a variety of AWS toolkits and debuggers to test and debug your serverless applications locally.",
+      "filename": "serverless-sam-cli-using-debugging",
+      "source": "sam"
+    },
+    "Target": {
+      "description": "Configures the AWS resource that EventBridge invokes when a rule is triggered.",
+      "filename": "sam-property-statemachine-statemachinescheduletarget",
+      "source": "sam"
+    },
+    "Telemetry in the AWS SAM CLI": {
+      "description": "At AWS, we develop and launch services based on what we learn from interactions with customers. We use customer feedback to iterate on our product. Telemetry is additional information that helps us to better understand our customers' needs, diagnose issues, and deliver features that improve the customer experience.",
+      "filename": "serverless-sam-telemetry",
+      "source": "sam"
+    },
+    "Testing and debugging serverless applications": {
+      "description": "With the AWS SAM command line interface (CLI), you can locally test and \"step-through\" debug your serverless applications before uploading your application to the AWS Cloud. You can verify whether your application is behaving as expected, debug what's wrong, and fix any issues, before going through the steps of packaging and deploying your application.",
+      "filename": "serverless-test-and-debug",
+      "source": "sam"
+    },
+    "Tutorial: Deploying a Hello World application": {
+      "description": "In this tutorial, you use the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) to complete the following:",
+      "filename": "serverless-getting-started-hello-world",
+      "source": "sam"
+    },
+    "Using OIDC authentication with AWS SAM pipeline": {
+      "description": "AWS Serverless Application Model (AWS SAM) supports OpenID Connect (OIDC) user authentication for Bitbucket, GitHub Actions, and GitLab continuous integration and continuous delivery (CI/CD) platforms. With this support, you can use authorized CI/CD user accounts from any of these platforms to manage your serverless application pipelines. Otherwise, you would need to create and manage multiple AWS Identity and Access Management (IAM) users to control access to AWS SAM pipelines.",
+      "filename": "deploying-with-oidc",
+      "source": "sam"
+    },
+    "Using nested applications": {
+      "description": "A serverless application can include one or more **nested applications**. You can deploy a nested application as a stand-alone artifact or as a component of a larger application.",
+      "filename": "serverless-sam-template-nested-applications",
+      "source": "sam"
+    },
+    "Using sam build": {
+      "description": "Use the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam build` command to prepare your serverless application for subsequent steps in your development workflow, such as local testing or deploying to the AWS Cloud. This command creates a `.aws-sam` directory that structures your application in a format and location that `sam local` and `sam deploy` require.",
+      "filename": "using-sam-cli-build",
+      "source": "sam"
+    },
+    "Using sam deploy": {
+      "description": "Use the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam deploy` command to deploy your serverless application to the AWS Cloud.",
+      "filename": "using-sam-cli-deploy",
+      "source": "sam"
+    },
+    "Using sam init": {
+      "description": "The AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam init` command provides options to initialize a new serverless application that consists of:",
+      "filename": "using-sam-cli-init",
+      "source": "sam"
+    },
+    "Using sam local": {
+      "description": "Use the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam local` command to test your serverless applications locally.",
+      "filename": "using-sam-cli-local",
+      "source": "sam"
+    },
+    "Using sam local generate\\-event": {
+      "description": "Use the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam local generate-event` subcommand to generate event payload samples for supported AWS services. You can then modify and pass these events to local resources for testing.",
+      "filename": "using-sam-cli-local-generate-event",
+      "source": "sam"
+    },
+    "Using sam local invoke": {
+      "description": "Use the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam local invoke` subcommand to initiate a one-time invocation of an AWS Lambda function locally.",
+      "filename": "using-sam-cli-local-invoke",
+      "source": "sam"
+    },
+    "Using sam local start\\-api": {
+      "description": "Use the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam local start-api` subcommand to run your AWS Lambda functions locally and test through a local HTTP server host. This type of test is helpful for Lambda functions that are invoked by an Amazon API Gateway endpoint.",
+      "filename": "using-sam-cli-local-start-api",
+      "source": "sam"
+    },
+    "Using sam local start\\-lambda": {
+      "description": "Use the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam local start-lambda` subcommand to invoke your AWS Lambda function through the AWS Command Line Interface (AWS CLI) or SDKs. This command starts a local endpoint that emulates AWS Lambda.",
+      "filename": "using-sam-cli-local-start-lambda",
+      "source": "sam"
+    },
+    "Using sam sync": {
+      "description": "The AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam sync` command provides options to quickly sync local application changes to the AWS Cloud. Use `sam sync` when developing your applications to:",
+      "filename": "using-sam-cli-sync",
+      "source": "sam"
+    },
+    "Using the AWS SAM CLI": {
+      "description": "Use the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) with AWS SAM templates and supported third-party integrations to build and run your serverless applications.",
+      "filename": "using-sam-cli",
+      "source": "sam"
+    },
+    "Using the AWS SAM CLI to upload local files at deployment": {
+      "description": "When developing, you will often find it beneficial to break up your application code into separate files to better organize and manage your application. A basic example of this is separating your AWS Lambda function code from your infrastructure code. You do this by organizing your Lambda function code in a subdirectory of your project and referencing its local path within your AWS Serverless Application Model (AWS SAM) template.",
+      "filename": "deploy-upload-local-files",
+      "source": "sam"
+    },
+    "Using the AWS SAM CLI with Serverless\\.tf for local debugging and testing": {
+      "description": "|  |",
+      "filename": "using-samcli-serverlesstf",
+      "source": "sam"
+    },
+    "Using the AWS SAM CLI with Terraform for local debugging and testing": {
+      "description": "|  |",
+      "filename": "using-samcli-terraform",
+      "source": "sam"
+    },
+    "Using the AWS Serverless Application Model \\(AWS SAM\\)": {
+      "description": "Use the AWS Serverless Application Model (AWS SAM) to build and run your serverless applications.",
+      "filename": "chapter-using-sam",
+      "source": "sam"
+    },
+    "Validate your AWS SAM applications with AWS CloudFormation Linter": {
+      "description": "AWS CloudFormation Linter (cfn-lint) is an open-source tool that you can use to perform detailed validation on your AWS CloudFormation templates. Cfn-lint contains rules that are guided by the AWS CloudFormation resource specification. Use cfn-lint to compare your resources against those rules to receive detailed messages on errors, warnings, or informational suggestions. Alternatively, create your own custom rules to validate against. To learn more about cfn-lint, see [cfn-lint](https://github.com/aws-cloudformation/cfn-lint) in the *AWS CloudFormation GitHub repository*.",
+      "filename": "validate-cfn-lint",
+      "source": "sam"
+    },
+    "Validating AWS SAM template files": {
+      "description": "Validate your templates with `sam validate`. Currently, this command validates that the template provided is valid JSON / YAML. As with most AWS SAM CLI commands, it looks for a `template.[yaml|yml]` file in your current working directory by default. You can specify a different template file/location with the `-t` or `--template` option.",
+      "filename": "serverless-sam-cli-using-validate",
+      "source": "sam"
+    },
+    "Verify the integrity of the AWS SAM CLI installer": {
+      "description": "When installing the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) using a package installer, you can verify its integrity before installation. This is an optional, but highly recommended step.",
+      "filename": "reference-sam-cli-install-verify",
+      "source": "sam"
+    },
+    "What is AWS SAM CLI support for Terraform?": {
+      "description": "|  |",
+      "filename": "what-is-terraform-support",
+      "source": "sam"
+    },
+    "What is the AWS Serverless Application Model \\(AWS SAM\\)?": {
+      "description": "The AWS Serverless Application Model (AWS SAM) is a toolkit that improves the developer experience of building and running serverless applications on AWS. AWS SAM consists of two primary parts:",
+      "filename": "what-is-sam",
+      "source": "sam"
+    },
+    "Working with layers": {
+      "description": "Using AWS SAM, you can include layers in your serverless applications. For more information about layers, see [AWS Lambda layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) in the *AWS Lambda Developer Guide*.",
+      "filename": "serverless-sam-cli-layers",
+      "source": "sam"
+    },
+    "Working with logs": {
+      "description": "To simplify troubleshooting, the AWS SAM CLI has a command called `sam logs`. This command lets you fetch logs generated by your Lambda function from the command line.",
+      "filename": "serverless-sam-cli-logging",
+      "source": "sam"
+    },
+    "Working with third\\-party services": {
+      "description": "This section provides documentation on using the AWS Serverless Application Model (AWS SAM) with third-party services.",
+      "filename": "working-with-third-party",
+      "source": "sam"
+    },
+    "sam build": {
+      "description": "Options for the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam build` command.",
+      "filename": "sam-cli-command-reference-sam-build",
+      "source": "sam"
+    },
+    "sam delete": {
+      "description": "Deletes an AWS SAM application by deleting the AWS CloudFormation stack, the artifacts that were packaged and deployed to Amazon S3 and Amazon ECR, and the AWS SAM template file.",
+      "filename": "sam-cli-command-reference-sam-delete",
+      "source": "sam"
+    },
+    "sam deploy": {
+      "description": "Options for the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam deploy` command.",
+      "filename": "sam-cli-command-reference-sam-deploy",
+      "source": "sam"
+    },
+    "sam init": {
+      "description": "Options for the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam init` command.",
+      "filename": "sam-cli-command-reference-sam-init",
+      "source": "sam"
+    },
+    "sam list": {
+      "description": "Outputs important information about the resources in your serverless application and the state of your serverless application. Use sam list before and after deployment to assist during local and cloud development.",
+      "filename": "sam-cli-command-reference-sam-list",
+      "source": "sam"
+    },
+    "sam list endpoints": {
+      "description": "Displays a list of cloud and local endpoints from your AWS CloudFormation stack. You can interact with these resources through the sam local and sam sync commands.",
+      "filename": "sam-cli-command-reference-sam-list-endpoints",
+      "source": "sam"
+    },
+    "sam list resources": {
+      "description": "Displays the resources in your AWS Serverless Application Model (AWS SAM) template that are created in AWS CloudFormation by the AWS SAM transform at deployment.",
+      "filename": "sam-cli-command-reference-sam-list-resources",
+      "source": "sam"
+    },
+    "sam list stack\\-outputs": {
+      "description": "Displays the outputs of your AWS CloudFormation stack from an AWS Serverless Application Model (AWS SAM) or AWS CloudFormation template. For more information on `Outputs`, see [Outputs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html) in the *AWS CloudFormation User Guide*.",
+      "filename": "sam-cli-command-reference-sam-list-stack-outputs",
+      "source": "sam"
+    },
+    "sam local generate\\-event": {
+      "description": "Options for the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam local generate-event` subcommand.",
+      "filename": "sam-cli-command-reference-sam-local-generate-event",
+      "source": "sam"
+    },
+    "sam local invoke": {
+      "description": "Options for the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam local invoke` subcommand.",
+      "filename": "sam-cli-command-reference-sam-local-invoke",
+      "source": "sam"
+    },
+    "sam local start\\-api": {
+      "description": "Options for the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam local start-api` subcommand.",
+      "filename": "sam-cli-command-reference-sam-local-start-api",
+      "source": "sam"
+    },
+    "sam local start\\-lambda": {
+      "description": "Options for the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam local start-lambda` subcommand.",
+      "filename": "sam-cli-command-reference-sam-local-start-lambda",
+      "source": "sam"
+    },
+    "sam logs": {
+      "description": "Fetches logs that are generated by your Lambda function.",
+      "filename": "sam-cli-command-reference-sam-logs",
+      "source": "sam"
+    },
+    "sam metadata resource": {
+      "description": "|  |",
+      "filename": "terraform-sam-metadata",
+      "source": "sam"
+    },
+    "sam package": {
+      "description": "Packages an AWS SAM application. This command creates a `.zip` file of your code and dependencies, and uploads the file to Amazon Simple Storage Service (Amazon S3). AWS SAM enables encryption for all files stored in Amazon S3. It then returns a copy of your AWS SAM template, replacing references to local artifacts with the Amazon S3 location where the command uploaded the artifacts.",
+      "filename": "sam-cli-command-reference-sam-package",
+      "source": "sam"
+    },
+    "sam pipeline bootstrap": {
+      "description": "This command generates the required AWS infrastructure resources to connect to your CI/CD system. This step must be run for each deployment stage in your pipeline prior to running the sam pipeline init command.",
+      "filename": "sam-cli-command-reference-sam-pipeline-bootstrap",
+      "source": "sam"
+    },
+    "sam pipeline init": {
+      "description": "This command generates a pipeline configuration file that your CI/CD system can use to deploy serverless applications using AWS SAM.",
+      "filename": "sam-cli-command-reference-sam-pipeline-init",
+      "source": "sam"
+    },
+    "sam publish": {
+      "description": "Publish an AWS SAM application to the AWS Serverless Application Repository. Takes a packaged AWS SAM template and publishes the application to the specified AWS Region.",
+      "filename": "sam-cli-command-reference-sam-publish",
+      "source": "sam"
+    },
+    "sam sync": {
+      "description": "Use the AWS Serverless Application Model Command Line Interface (AWS SAM CLI) `sam sync` command to sync local application changes to the AWS Cloud.",
+      "filename": "sam-cli-command-reference-sam-sync",
+      "source": "sam"
+    },
+    "sam traces": {
+      "description": "Fetches AWS X-Ray traces in your AWS account in the AWS Region.",
+      "filename": "sam-cli-command-reference-sam-traces",
+      "source": "sam"
+    },
+    "sam validate": {
+      "description": "Verifies whether an AWS SAM template file is valid.",
+      "filename": "sam-cli-command-reference-sam-validate",
+      "source": "sam"
+    }
+  }
+}


### PR DESCRIPTION
The `index-sources/sam.json` file was generated from the last state of the aws-sam-developer-guide that still had content
(https://github.com/awsdocs/aws-sam-developer-guide/tree/42be629401362fdadf87cfff061662d0d08c3968). The `hack/generate-index-cfn.py` script from
1a4fea65d80eb014afa4768f4b9bb23b791696bc was used with slight modification to create the structure of the file as committed.