### PR TITLE
Add a new version of the CFN index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: |
-          extension/index/cfn.js
+          extension/index/cfn.v2.js
           json-indices/cfn.json
+          json-indices/cfn.v2.json
         key: indices-cfnlint-${{ steps.submodule-hashes.outputs.cfnlint-hash }}-${{ hashFiles('hack/generate-index-cfn.py') }}
     - name: 'botocore: index cache'
       id: cache-botocore
@@ -111,12 +112,18 @@ jobs:
       run: |
         hack/generate-index-cli.py
         hack/generate-index-cli.py --export-as-json
-    - name: 'aws-cli: verify generated index'
+    - name: 'aws-cli: verify generated index (v1)'
       if: steps.cache-awscli.outputs.cache-hit != 'true'
       run: |
         node_modules/.bin/ajv validate \
           -s hack/index-schemas/cli.schema.json \
           -d json-indices/cli.json
+    - name: 'aws-cli: verify generated index (v2)'
+      if: steps.cache-awscli.outputs.cache-hit != 'true'
+      run: |
+        node_modules/.bin/ajv validate \
+          -s hack/index-schemas/cli.v2.schema.json \
+          -d json-indices/cli.v2.json
 
     - name: 'cfn-lint: Generate index'
       if: steps.cache-cfnlint.outputs.cache-hit != 'true'

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -58,8 +58,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: |
-          extension/index/cfn.js
+          extension/index/cfn.v2.js
           json-indices/cfn.js
+          json-indices/cfn.v2.js
         key: indices-cfnlint-${{ steps.submodule-hashes.outputs.cfnlint-hash }}-${{ hashFiles('hack/generate-index-cfn.py') }}
     - name: 'botocore: index cache'
       id: cache-botocore
@@ -83,12 +84,18 @@ jobs:
       run: |
         hack/generate-index-cli.py
         hack/generate-index-cli.py --export-as-json
-    - name: 'aws-cli: verify generated index'
+    - name: 'aws-cli: verify generated index (v1)'
       if: steps.cache-awscli.outputs.cache-hit != 'true'
       run: |
         node_modules/.bin/ajv validate \
           -s hack/index-schemas/api.schema.json \
           -d json-indices/api.json
+    - name: 'aws-cli: verify generated index (v2)'
+      if: steps.cache-awscli.outputs.cache-hit != 'true'
+      run: |
+        node_modules/.bin/ajv validate \
+          -s hack/index-schemas/cli.v2.schema.json \
+          -d json-indices/cli.v2.json
 
     - name: 'cfn-lint: Generate index'
       if: steps.cache-cfnlint.outputs.cache-hit != 'true'

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include core/extension.mk
 
 .PHONY: chrome
 
-indices = extension/index/api.js extension/index/cfn.js extension/index/cli.js
+indices = extension/index/api.js extension/index/cfn.v2.js extension/index/cli.js
 
 prepare-unlisted:
 	@printf "unlisted" > hack/jsonnet-fragments/version-suffix
@@ -26,9 +26,9 @@ empty-index-api:
 	)
 empty-index-cfn:
 	$(if \
-		$(wildcard extension/index/cfn.js), \
+		$(wildcard extension/index/cfn.v2.js), \
 		, \
-		echo "var cfnSearchIndex={};" > extension/index/cfn.js \
+		echo "var cfnV2SearchIndex={};" > extension/index/cfn.v2.js \
 	)
 empty-index-cli:
 	$(if \
@@ -43,7 +43,7 @@ extension/index/api.js:
 	@echo "Generating API index"
 	hack/generate-index-api.py
 
-extension/index/cfn.js:
+extension/index/cfn.v2.js:
 	@echo "Generating CFN index"
 	hack/generate-index-cfn.py
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ You can use the following kinds of search-queries:
 
     ```
     https://raw.githubusercontent.com/pitkley/aws-search-extension/indices/api.json
-    https://raw.githubusercontent.com/pitkley/aws-search-extension/indices/cfn.json
+    https://raw.githubusercontent.com/pitkley/aws-search-extension/indices/cfn.v2.json
     https://raw.githubusercontent.com/pitkley/aws-search-extension/indices/cli.json
     ```
 

--- a/extension/main.js
+++ b/extension/main.js
@@ -17,7 +17,7 @@
     Omnibox,
     UpdateCommand,
     apiSearchIndex,
-    cfnSearchIndex,
+    cfnV2SearchIndex,
     cliSearchIndex,
     storageGetOrDefault,
 */
@@ -26,7 +26,7 @@ const COMMAND_PREFIX = "!";
 const c = new Compat();
 (async () => {
     const apiSearcher = new ApiSearcher(await storageGetOrDefault("index-api", apiSearchIndex));
-    const cfnSearcher = new CfnSearcher(await storageGetOrDefault("index-cfn", cfnSearchIndex));
+    const cfnSearcher = new CfnSearcher(await storageGetOrDefault("index-cfn", cfnV2SearchIndex));
     const cliSearcher = new CliSearcher(await storageGetOrDefault("index-cli", cliSearchIndex));
 
     const updateCommand = new UpdateCommand([

--- a/extension/search/cfn.js
+++ b/extension/search/cfn.js
@@ -20,17 +20,17 @@ class CfnSearcher {
     }
 
     static processRawIndex(rawIndex) {
-        const index = Object.entries(rawIndex).map(([name, [path, description, source]]) => {
+        const index = Object.entries(rawIndex).map(([name, [url, description, source]]) => {
             return {
                 name,
-                path,
+                url,
                 description,
                 source,
             };
         }).sort(({name: a}, {name: b}) => lengthThenLexicographicSort(a, b));
         const searcher = new FuzzySearch(
             index,
-            ["name", "description"],
+            ["name"],
             {sort: true},
         );
 
@@ -48,7 +48,7 @@ class CfnSearcher {
 
     async updateIndexFromGithub() {
         // Retrieve pre-built JSON-index from GitHub.
-        const response = await fetch(CONSTANTS.INDEX.forIndexId("cfn"));
+        const response = await fetch(CONSTANTS.INDEX.forIndexId("cfn.v2"));
         const indexData = await response.json();
 
         // Store the index in the extension-storage.
@@ -63,13 +63,16 @@ class CfnSearcher {
     }
 
     format(index, doc) {
-        let content;
-        let description = `${c.match(c.escape(doc.name))} - ${c.dim(c.escape(doc.description))}`;
+        const content = doc.url;
+
+        let description = `${c.match(c.escape(doc.name))}`;
+        if (doc.description) {
+            description = description + ` - ${c.dim(c.escape(doc.description))}`;
+        }
+
         if (doc.source === "sam") {
-            content = `https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/${doc.path}.html`;
             description = "[SAM] " + description;
         } else {
-            content = `https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/${doc.path}.html`;
             description = "[CFN] " + description;
         }
 

--- a/extension/service-worker.js
+++ b/extension/service-worker.js
@@ -26,7 +26,7 @@ importScripts(
     "command/update.js",
     "search/lib.js",
     "index/api.js",
-    "index/cfn.js",
+    "index/cfn.v2.js",
     "index/cli.js",
     "search/api.js",
     "search/cfn.js",

--- a/hack/index-schemas/cfn.v2.schema.json
+++ b/hack/index-schemas/cfn.v2.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "minProperties": 1,
+  "patternProperties": {
+    ".*": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": [
+        {
+          "type": "string",
+          "pattern": "^https://.+"
+        },
+        {
+          "type": ["string", "null"]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
With the index datasources changing and containing full documentation URLs, it made sense to no longer build up the URL to the CFN-page in the extension, but have it in the index instead. We also can and should no longer rely on documentation to be present, so the newer version of the index makes the presence of documentation optional.

The change made here does _not_ remove the "old" V1 index, at least not from the `indices` branch. It does not bundle both versions with the extension, since that is unnecessary, but old versions of the extension will still be able to get the version 1 index without issues going forward.